### PR TITLE
Allow force delete ecr registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ module "waypoint-ecs" {
   # Module config
   alb_internal = false
   create_ecr   = true
+  
+  # Uncomment below to enable deleting the registry even if there are images
+  # force_delete_ecr = true
 
   # Existing infrastructure
   aws_region       = "us-east-1"

--- a/ecr.tf
+++ b/ecr.tf
@@ -8,8 +8,8 @@ module "ecr" {
 
   count = var.create_ecr ? 1 : 0
 
-
   repository_name         = local.ecs_repository_name
+  repository_force_delete = var.force_delete_ecr
   create_lifecycle_policy = false
 
   tags = var.tags

--- a/variables.tf
+++ b/variables.tf
@@ -61,6 +61,19 @@ variable "tags" {
   default     = {}
 }
 
+variable "force_delete_ecr" {
+  description = <<EOF
+    Controls if an ECR repository should be forcibly deleted.
+    Waypoint doesn't delete images from a registry. If there
+    have been Waypoint builds and you try to `terraform destroy`
+    the ECR repository resource, and this variable is false, the
+    destroy will fail citing existing images. If this variable
+    is true, it will forcibly delete all the images
+  EOF
+  type        = bool
+  default     = false
+}
+
 ### Required Infrastructure connections, necessary for this module to create it's resources.
 
 variable "vpc_id" {


### PR DESCRIPTION
Optionally! Waypoint doesn't clean up images when it deletes a project, so the ecr registry deletion will fail if waypoint has performed a successful build _and_ this variable isn't set.