### PR TITLE
Fix typo - consecutive 'the' occurrences

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -30,7 +30,7 @@ output "security_group_id" {
 output "private_subnets" {
   value       = var.private_subnets
   description = <<EOF
-    List of private subnet IDs to assign the the ENIs of ECS tasks.
+    List of private subnet IDs to assign the ENIs of ECS tasks.
     Same as input variable private_subnets.
   EOF
 }

--- a/variables.tf
+++ b/variables.tf
@@ -86,7 +86,7 @@ variable "vpc_id" {
 
 variable "private_subnets" {
   description = <<EOF
-    List of private subnet IDs to assign the the ENIs of ECS tasks, and internal ALBs.
+    List of private subnet IDs to assign the ENIs of ECS tasks, and internal ALBs.
     Only required if alb_internal is true, or if you wish to rely on this module's
     private_subnets output.
   EOF


### PR DESCRIPTION
Remove consecutive occurrences of 'the'
`s/the the /the /g`