### PR TITLE
Add role policy attachments for custom user input IAM policies

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -50,5 +50,16 @@ resource "aws_iam_role" "task_role" {
   inline_policy {}
 }
 
+data "aws_iam_policy" "custom_task_role_policies" {
+  for_each = var.task_role_custom_policy_arns
+  arn      = each.value
+}
+
+resource "aws_iam_role_policy_attachment" "custom_task_role_policies" {
+  for_each   = data.aws_iam_policy.custom_task_role_policies
+  role       = aws_iam_role.task_role.name
+  policy_arn = each.value.arn
+}
+
 # Future improvement: add policy to waypoint runner role to allow registry push
 

--- a/variables.tf
+++ b/variables.tf
@@ -138,3 +138,11 @@ variable "log_group_name" {
   EOF
   type        = string
 }
+
+variable "task_role_custom_policy_arns" {
+  description = <<EOF
+A list of IAM policy ARNs which are desired to be attached to the IAM task role.
+EOF
+  type        = list(string)
+  default     = []
+}


### PR DESCRIPTION
This PR enables users of this module to attach custom, pre-existing IAM policies to the task role created for the AWS ECS service. This is useful for services which require permissions beyond what is provided by default for the task role, such as a container with a DataDog agent sidecar.