### PR TITLE
Fix usage of for_each for IAM policy attachments.

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -51,12 +51,14 @@ resource "aws_iam_role" "task_role" {
 }
 
 data "aws_iam_policy" "custom_task_role_policies" {
-  for_each = var.task_role_custom_policy_arns
-  arn      = each.value
+  count    = length(var.task_role_custom_policy_arns)
+  arn      = var.task_role_custom_policy_arns[count.index]
 }
 
 resource "aws_iam_role_policy_attachment" "custom_task_role_policies" {
-  for_each   = data.aws_iam_policy.custom_task_role_policies
+  for_each = {
+    for policy in data.aws_iam_policy.custom_task_role_policies : policy.name => policy
+  }
   role       = aws_iam_role.task_role.name
   policy_arn = each.value.arn
 }


### PR DESCRIPTION
This PR removes the usage of `for_each` for the IAM policy attachments - `for_each` does not work with `list` types. This has been updated to use `count` in the data source, and `for` within the `for_each` of the policy attachment resource itself.